### PR TITLE
fix logic to get longest subsequence

### DIFF
--- a/src/simple_diff.ml
+++ b/src/simple_diff.ml
@@ -67,10 +67,11 @@ module Make(Item : Comparable) = struct
             let new_subsequence = prev_subsequence + 1 in
             Hashtbl.add overlap old_index new_subsequence;
 
-            if new_subsequence > !longest_subsequence then
+            if new_subsequence > !longest_subsequence then (
               sub_start_old := old_index - new_subsequence + 1;
-            sub_start_new := new_index - new_subsequence + 1;
-            longest_subsequence := new_subsequence;
+              sub_start_new := new_index - new_subsequence + 1;
+              longest_subsequence := new_subsequence;
+            )
           ) indices;
       ) new_lines;
 


### PR DESCRIPTION
Since I don't know how to run test so I didn't add a test case, you can reproduce the bug with such code below:

```ml
  let result = Diff.get_diff
    [| "aaa"; "bbb"; "ccc"; "ddd"; "eee" |]
    [| "aaa"; "ccc"; "xxxx"; "eee" |]
  in
  List.iter (fun d -> match d with
    | Diff.Deleted items -> Array.iter (fun s -> printf "- %s\n" s) items
    | Diff.Added items -> Array.iter (fun s -> printf "+ %s\n" s) items
    | Diff.Equal items -> Array.iter (fun s -> printf "  %s\n" s) items
  ) result;
```

becomes

```
+ aaa
+ ccc
+ xxxx
  eee
- bbb
- ccc
- ddd
- eee
```
